### PR TITLE
Feature/clear history button

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -27,7 +27,8 @@ var parkSelections = document.querySelector("#park-list");
 var selectionEl = document.getElementById('park-list');
 var stateParkFetchBtn = document.getElementById('fetch-park-info');
 var carousel = document.querySelector('.carousel');
-var clearHistory = document.querySelector("#clear-history");
+var clearHistoryBtn = document.querySelector("#clear-history");
+var historyContainerEl = document.getElementsByClassName("collection");
 var map = document.querySelector("#googleMap");
 // locally retrive Google API key
 var storedValue = localStorage.getItem("key");
@@ -76,7 +77,6 @@ function showMap() {
 // POPULATE PARK NAMES DROPDOWN FROM LOCALSTORAGE (not done)
 function populateParkNames() {
     var parksInState = JSON.parse(localStorage.getItem("all-parks")) || [];
-    // var selectionEl = document.querySelectorAll('select');
     var count = parksInState?parksInState.length - 1: 0; // sets counter to begin at index 0 to match localStorage order
     var parkOption = document.getElementsByClassName(".option")
     if (parkOption) {
@@ -347,8 +347,16 @@ var instance = M.Autocomplete.getInstance(usState);
 // })
 
 // CLEAR SEARCH HISTORY
-clearHistory.addEventListener("click", function() {
+clearHistoryBtn.addEventListener("click", function() {
+    // empties "park-history"
     localStorage.clear("park-history");
+    // checks if search history is on page
+    if (document.querySelector(".collection-item")) {
+        // for every item, remove them from the end until empty
+        for (const unwantedHistory of [...historyContainerEl]) {
+            historyContainerEl.lastChild.remove();
+        }
+    }
     /*
     - removes children from container
     - restores placeholder text/images

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -15,9 +15,6 @@
     - separate modal into two sections: 
         - (1) gets data from localStorage "this-park" (relevant info)
         - (2) gets data from google maps API call (travel distance and time)
-- function to clear history
-    - clear localStorage by keyword: "park-history"
-    - hide empty buttons
 */
 // --------------- GLOBAL VARIABLES ---------------
 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -82,19 +82,18 @@ function showMap() {
 // POPULATE PARK NAMES DROPDOWN FROM LOCALSTORAGE (not done)
 function populateParkNames() {
     var parksInState = JSON.parse(localStorage.getItem("all-parks")) || [];
-    var count = parksInState?parksInState.length - 1: 0; // sets counter to begin at index 0 to match localStorage order
-    var parkOption = document.getElementsByClassName(".option")
+    var count = parksInState ? parksInState.length - 1 : 0; // sets counter to begin at index 0 to match localStorage order
+    var parkOption = document.getElementsByClassName(".option");
     if (parkOption) {
         for (const unwantedPark of [...selectionEl]) {
             selectionEl.lastChild.remove();
         }
-        var placeholderOption = document.createElement("option", {
-            id: "placeholder-option",
-            value: "",
-            disabled: true,
-            selected: true,
-            textContent: "Parks"
-        });
+        var placeholderOption = document.createElement("option")
+        placeholderOption.setAttribute("id", "placeholder-option");
+        placeholderOption.setAttribute("value", "");
+        placeholderOption.setAttribute("disabled", true);
+        placeholderOption.setAttribute("selected", true);
+        placeholderOption.textContent = "PARKS"
         selectionEl.appendChild(placeholderOption);
     }
     for (const value of parksInState.reverse()) { // fixes order to show A-Z on screen

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -153,24 +153,6 @@ function getStateParkApi(stateValue) {
     return parksInState;
 }
 
-// PARK NAMES LIST DROPDOWN (unused)
-// document.addEventListener('DOMContentLoaded', function() {
-//     // var parkListItem = document.querySelector(".park-item");
-//     var instance = M.Dropdown.getInstance(parkListItem);
-//     M.Dropdown.init(dropdownTrigger, {
-//         coverTrigger: false,
-//         onCloseStart: function() {
-//             // parkListItem.addEventListener("change", function(event) {
-//             //     console.log(event)
-//             // })
-//             console.log("hello")
-
-//         }
-//     });
-// });
-
-
-
 // GOOGLE MAPS API CONTROLS
 
 // set map options (javascript.js)

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -27,6 +27,7 @@ var parkSelections = document.querySelector("#park-list");
 var selectionEl = document.getElementById('park-list');
 var stateParkFetchBtn = document.getElementById('fetch-park-info');
 var carousel = document.querySelector('.carousel');
+var clearHistory = document.querySelector("#clear-history");
 var map = document.querySelector("#googleMap");
 // locally retrive Google API key
 var storedValue = localStorage.getItem("key");
@@ -344,3 +345,12 @@ var instance = M.Autocomplete.getInstance(usState);
 // instance.onAutocomplete(function(fill) {
 //     console.log(fill)
 // })
+
+// CLEAR SEARCH HISTORY
+clearHistory.addEventListener("click", function() {
+    localStorage.clear("park-history");
+    /*
+    - removes children from container
+    - restores placeholder text/images
+    */
+})

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -348,9 +348,8 @@ var instance = M.Autocomplete.getInstance(usState);
 
 function clearHistory() {
     historyContainerEl.remove()
-    // for (var i = 0; i < historyContainerEl.children.length; i++) {
-    //     historyContainerEl.removeChild([...historyContainerEl.children][i]);
-    // }
+    var historyCardEl = document.querySelector(".search-history-card-container");
+    historyCardEl.setAttribute("class", "hide")
 }
 
 // CLEAR SEARCH HISTORY
@@ -360,13 +359,8 @@ clearHistoryBtn.addEventListener("click", function() {
     // checks if search history is on page
     if (historyContainerEl.hasChildNodes()) {
         clearHistory()
-        // for every item, remove them from the end until empty
-    //     for (const unwantedHistory of [...historyContainerEl]()) {
-    //         historyContainerEl.lastChild.remove();
-    //     }
     }
     /*
-    - removes children from container
     - restores placeholder text/images
     */
 })

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -87,6 +87,7 @@ function populateParkNames() {
             value: "",
             disabled: true,
             selected: true,
+            textContent: "Parks"
         });
         selectionEl.appendChild(placeholderOption);
     }

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -59,6 +59,14 @@ function defaultView() {
 }
 defaultView();
 
+// CLEAR HISTORY AND HIDE CARD
+function clearHistory() {
+    historyContainerEl.remove()
+    var historyCardEl = document.querySelector(".search-history-card-container");
+    historyCardEl.setAttribute("class", "hide")
+}
+
+// MAP FUNCTIONALITY
 function populateMap() {
     /*
     - insert Josh's code that shows map address
@@ -67,8 +75,8 @@ function populateMap() {
 
 // CHANGES ELEMENTS VISIBLE USING MATERIALIZE
 function showMap() {
-    // checks if "this-park" and "user-address" exists (implies map is populated), then changes view
-    if ((JSON.parse(localStorage.getItem("this-park")) !== null) && (JSON.parse(localStorage.getItem("user-address")) !== null)) {
+    // checks if "all-parks" and "user-address" exists (implies map is populated), then changes view
+    if ((JSON.parse(localStorage.getItem("all-parks")) !== null) && (JSON.parse(localStorage.getItem("user-address")) !== null)) {
         carousel.classList.add("hide");
         map.classList.remove("hide");
     }
@@ -346,12 +354,6 @@ var instance = M.Autocomplete.getInstance(usState);
 //     console.log(fill)
 // })
 
-function clearHistory() {
-    historyContainerEl.remove()
-    var historyCardEl = document.querySelector(".search-history-card-container");
-    historyCardEl.setAttribute("class", "hide")
-}
-
 // CLEAR SEARCH HISTORY
 clearHistoryBtn.addEventListener("click", function() {
     // empties "park-history"
@@ -360,7 +362,4 @@ clearHistoryBtn.addEventListener("click", function() {
     if (historyContainerEl.hasChildNodes()) {
         clearHistory()
     }
-    /*
-    - restores placeholder text/images
-    */
 })

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -346,16 +346,24 @@ var instance = M.Autocomplete.getInstance(usState);
 //     console.log(fill)
 // })
 
+function clearHistory() {
+    historyContainerEl.remove()
+    // for (var i = 0; i < historyContainerEl.children.length; i++) {
+    //     historyContainerEl.removeChild([...historyContainerEl.children][i]);
+    // }
+}
+
 // CLEAR SEARCH HISTORY
 clearHistoryBtn.addEventListener("click", function() {
     // empties "park-history"
     localStorage.clear("park-history");
     // checks if search history is on page
-    if (document.querySelector(".collection-item")) {
+    if (historyContainerEl.hasChildNodes()) {
+        clearHistory()
         // for every item, remove them from the end until empty
-        for (const unwantedHistory of [...historyContainerEl]) {
-            historyContainerEl.lastChild.remove();
-        }
+    //     for (const unwantedHistory of [...historyContainerEl]()) {
+    //         historyContainerEl.lastChild.remove();
+    //     }
     }
     /*
     - removes children from container

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -117,70 +117,38 @@ function getStateParkApi(stateValue) {
         return response.json();
     })
     .then(function (parkData){
-    parksInState = JSON.parse(localStorage.getItem("all-parks")) || [];
-    // resets value to [] instead of localStorage.getItem
-    for (const item of parkData.data) {
-        var parkFees
-        if (item.entranceFees.length === 0) {
-            parkFees = "Call for updated prices!"
-        } else {
-            parkFees = item.entranceFees[0].description;
-        }
-        if (item.addresses[0].stateCode.toLowerCase() !== stateValue.toLowerCase()) {
-            continue;
-        }
-        // pushes anonymous object of each park to array list
-        parksInState.push({
-            name: item.name,
-            street: item.addresses[0].line1,
-            city: item.addresses[0].city,
-            state: item.addresses[0].stateCode,
-            zip: item.addresses[0].postalCode,
-            open: item.operatingHours[0].description,
-            monHours: item.operatingHours[0].standardHours.monday,
-            tueHours: item.operatingHours[0].standardHours.tuesday,
-            wedHours: item.operatingHours[0].standardHours.wednesday,
-            thuHours: item.operatingHours[0].standardHours.thursday,
-            friHours: item.operatingHours[0].standardHours.friday,
-            satHours: item.operatingHours[0].standardHours.saturday,
-            sunHours: item.operatingHours[0].standardHours.sunday,
-            fees: parkFees,
-            weather: item.weatherInfo
-        }
-    )}
-    // for (var i = 0; i < parkData.data.length; i++) {
-    //     var parkFees
-    //     if (parkData.data[i].entranceFees.length === 0) {
-    //         parkFees = "Call for updated prices!"
-    //     } else {
-    //         parkFees = parkData.data[i].entranceFees[0].description;
-    //     }
-    //     if (parkData.data[i].addresses[0].stateCode.toLowerCase() !== stateValue.toLowerCase()) {
-    //         continue;
-    //     }
-    //     // pushes anonymous object of each park to array list
-    //     parksInState.push({
-    //         name: parkData.data[i].name,
-    //         optionValue: i,
-    //         street: parkData.data[i].addresses[0].line1,
-    //         city: parkData.data[i].addresses[0].city,
-    //         state: parkData.data[i].addresses[0].stateCode,
-    //         zip: parkData.data[i].addresses[0].postalCode,
-    //         open: parkData.data[i].operatingHours[0].description,
-    //         monHours: parkData.data[i].operatingHours[0].standardHours.monday,
-    //         tueHours: parkData.data[i].operatingHours[0].standardHours.tuesday,
-    //         wedHours: parkData.data[i].operatingHours[0].standardHours.wednesday,
-    //         thuHours: parkData.data[i].operatingHours[0].standardHours.thursday,
-    //         friHours: parkData.data[i].operatingHours[0].standardHours.friday,
-    //         satHours: parkData.data[i].operatingHours[0].standardHours.saturday,
-    //         sunHours: parkData.data[i].operatingHours[0].standardHours.sunday,
-    //         fees: parkFees,
-    //         weather: parkData.data[i].weatherInfo
-    //     })
-    // }
-    // saves all parks within one state into localStorage as stringified array of objects
-    localStorage.setItem("all-parks", JSON.stringify(parksInState));
-    populateParkNames()
+        console.log(parkData)
+        parksInState = JSON.parse(localStorage.getItem("all-parks")) || [];
+        // resets value to [] instead of localStorage.getItem
+        for (const item of parkData.data) {
+            if (item.addresses[0].stateCode.toLowerCase() !== stateValue.toLowerCase()) {
+                continue;
+            }
+            // var thing1 = {};
+            // item.addresses[0].city.length === 0 ? "nothing" : thing1['city'] = item.addresses[0].city
+            // pushes anonymous object of each park to array list
+            parksInState.push({ // checks if value exists, then adds a placeholder or the API-provided value
+                name: item.name === null ? "One of the best parks in state!" : item.name,
+                street: item.addresses[0].line1 === null ? "Please call for directions." : item.addresses[0].line1,
+                city: item.addresses[0].city === null ? "" : item.addresses[0].city,
+                state: item.addresses[0].stateCode === null ? "" : item.addresses[0].stateCode,
+                zip: item.addresses[0].postalCode === null ? "" : item.addresses[0].postalCode,
+                open: item.operatingHours.length === 0 ? "Please call for updated hours." : item.operatingHours[0].description,
+                monHours: item.operatingHours.length === 0 ? "" : item.operatingHours[0].standardHours.monday,
+                tueHours: item.operatingHours.length === 0 ? "" : item.operatingHours[0].standardHours.tuesday,
+                wedHours: item.operatingHours.length === 0 ? "" : item.operatingHours[0].standardHours.wednesday,
+                thuHours: item.operatingHours.length === 0 ? "" : item.operatingHours[0].standardHours.thursday,
+                friHours: item.operatingHours.length === 0 ? "" : item.operatingHours[0].standardHours.friday,
+                satHours: item.operatingHours.length === 0 ? "" : item.operatingHours[0].standardHours.saturday,
+                sunHours: item.operatingHours.length === 0 ? "" : item.operatingHours[0].standardHours.sunday,
+                fees: item.entranceFees.length === 0 ? "Call or visit our site for updated prices!" : item.entranceFees[0].description,
+                weather: item.weatherInfo === null ? "" : item.weatherInfo
+            }
+        )}
+        // saves all parks within one state into localStorage as stringified array of objects
+        localStorage.setItem("all-parks", JSON.stringify(parksInState));
+        populateParkNames()
+        console.log(parksInState)
     })
     return parksInState;
 }

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,6 +1,4 @@
 /*
-- MIKE: save one park data into localStorage under "this-park"
-    - one park can be in this spot, use splice to remove the other one when a user switches park
 - save one park ADDRESS into localStorage under "park-address"
     - one park can be in this spot, use splice to remove the other one when a user switches park.
     - grab park address from localStorage keyword "this-park"
@@ -26,6 +24,7 @@
 // DOM query selectors
 var usState = document.querySelector('.autocomplete-state');
 var parkSelections = document.querySelector("#park-list");
+var selectionEl = document.getElementById('park-list');
 var stateParkFetchBtn = document.getElementById('fetch-park-info');
 var carousel = document.querySelector('.carousel');
 var map = document.querySelector("#googleMap");
@@ -74,18 +73,35 @@ function showMap() {
 }
 
 // POPULATE PARK NAMES DROPDOWN FROM LOCALSTORAGE (not done)
-function populateParkNames(parksInState) {
+function populateParkNames() {
     var parksInState = JSON.parse(localStorage.getItem("all-parks")) || [];
+    // var selectionEl = document.querySelectorAll('select');
     var count = parksInState?parksInState.length - 1: 0; // sets counter to begin at index 0 to match localStorage order
+    var parkOption = document.getElementsByClassName(".option")
+    if (parkOption) {
+        for (const unwantedPark of [...selectionEl]) {
+            selectionEl.lastChild.remove();
+        }
+        var placeholderOption = document.createElement("option", {
+            id: "placeholder-option",
+            value: "",
+            disabled: true,
+            selected: true,
+        });
+        selectionEl.appendChild(placeholderOption);
+    }
     for (const value of parksInState.reverse()) { // fixes order to show A-Z on screen
         var selectOption = document.createElement("option"); // creates option
+        selectOption.setAttribute("class", "option"); // adds class of option
         selectOption.setAttribute("value", count); // sets attribute of value number
         selectOption.textContent = value.name; // sets name of park
         document.querySelector("option").after(selectOption); // adds new option after last option
         count --; // counter decreases by one
     }
+    var elems = document.querySelectorAll('select');
+    M.FormSelect.init(elems);
 }
-populateParkNames() // calling on refresh for testing purposes
+// populateParkNames() // calling on refresh for testing purposes
 
 // NATIONAL PARK SERVICES API (done)
 
@@ -163,6 +179,7 @@ function getStateParkApi(stateValue) {
     // }
     // saves all parks within one state into localStorage as stringified array of objects
     localStorage.setItem("all-parks", JSON.stringify(parksInState));
+    populateParkNames()
     })
     return parksInState;
 }
@@ -287,17 +304,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
 // CREATE PARK NAMES LIST SELECTOR
 document.addEventListener('DOMContentLoaded', function() {
-    var selectionEl = document.querySelectorAll('select');
-    M.FormSelect.init(selectionEl, { 
-        // dropdownOptions: (function() {
-        //     var allParkNames = []
-        //     for (const item of localStorage.getItem("all-parks")) {
-        //         console.log("we in here: ", item)
-        //         allParkNames.push(item.name);
-        //     }
-        //     return allParkNames;
-        // })()
-    });
+    // var selectionEl = document.querySelectorAll('select');
+    M.FormSelect.init(selectionEl);
 });
 
 // RETURN VALUE FROM PARK NAMES LIST SELECTOR
@@ -305,6 +313,7 @@ parkSelections.addEventListener("change", function(event) {
     event.preventDefault()
     var indexLocation = event.target.value;
     console.log("value #: " + indexLocation);
+    console.log(instance.getSelectedValues())
     return indexLocation;
     /* 
     - is it possible to identify the textContent of the selected item instead of value number???

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -28,7 +28,7 @@ var selectionEl = document.getElementById('park-list');
 var stateParkFetchBtn = document.getElementById('fetch-park-info');
 var carousel = document.querySelector('.carousel');
 var clearHistoryBtn = document.querySelector("#clear-history");
-var historyContainerEl = document.getElementsByClassName("collection");
+var historyContainerEl = document.getElementById("history-collection");
 var map = document.querySelector("#googleMap");
 // locally retrive Google API key
 var storedValue = localStorage.getItem("key");

--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
                                 <span class="card-title">Search History!</span>
                                 <!-- Use JS to create and populate using localStorage data -->
                                 <div class="search-history-list">
-                                    <div class="collection">
+                                    <div class="collection" id="history-collection">
                                         <a href="#!" class="collection-item">Park 1
                                             <i class="search-history-icon tiny material-icons">call_made</i>
                                         </a>

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
                                         <div class="row">
                                             <div class="input-field col s10">
                                                 <i class="material-icons prefix">location_on</i>
-                                                <input type="text" id="autocomplete-input" class="autocomplete-state">
+                                                <input type="text" id="autocomplete-input" autocomplete="off" class="autocomplete-state">
                                                 <label for="autocomplete-input">STATE</label>
                                             </div>
                                         </div>
@@ -72,7 +72,7 @@
                                     <p>Select a Park</p>
                                     <div class="input-field col s12">
                                         <select id="park-list">
-                                            <option id="placeholder-option" value="" disabled selected>Parks</option>
+                                            <option id="placeholder-option" value="" disabled selected>PARKS</option>
                                         </select>
                                     </div>
                                 </div>

--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
                                     <p>Select a Park</p>
                                     <div class="input-field col s12">
                                         <select id="park-list">
-                                            <option value="" disabled selected>Parks</option>
+                                            <option id="placeholder-option" value="" disabled selected>Parks</option>
                                         </select>
                                     </div>
                                 </div>


### PR DESCRIPTION
### Hi, here is what's new!

1. BUG FIX: the placeholder word "parks" in the park names dropdown no longer disappears after the user switches to a new state list
2. NEW FEATURE: when the user clicks Clear History button, the HTML child elements (anchor tags <a> and icons <i>) are removed from the container element. Watch DevTools HTML to test
3. NEW FEATURE: when the user clicks Clear History and the child elements are removed, the Search History card disappears from view because it is no longer in use
4. BUG FIX: browers that save autocomplete values by default no longer compete with the Materialize autocomplete in the Select a US State box

### Up next:

- google maps Origin input field functionality needs to be transferred to User Address input field, then the Origin input field needs to be removed entirely
- values from the User Address input field need to be saved into localStorage under "user-address" after GO! button is clicked
- values from Select a Park dropdown need to be populated into the modal after GO! button is clicked
- carousel images need to be hidden and replaced with Google Map after GO! button is clicked. carousel images may need to be adjusted for size to match the map size